### PR TITLE
Make the socket permanent

### DIFF
--- a/lib/Collectd/Plugins/Graphite.pm
+++ b/lib/Collectd/Plugins/Graphite.pm
@@ -86,6 +86,7 @@ Copyright 2011 Joe Miller.
 
 my $buff = '';
 my $sock_timeout  = 10;
+my $socket;
 
 # config vars.  These can be overridden in collectd.conf
 my $buffer_size   = 8192;
@@ -159,23 +160,26 @@ sub graphite_write {
 
 sub send_to_graphite {
      return 0 if length($buff) == 0;
-     my $sock = IO::Socket::INET->new(PeerAddr => $graphite_host,
-                                      PeerPort => $graphite_port,
-                                      Proto    => 'tcp',
-                                      Timeout  => $sock_timeout);
-     unless ($sock) {
+     $socket ||= IO::Socket::INET->new(PeerAddr => $graphite_host,
+                                     PeerPort => $graphite_port,
+                                     Proto    => 'tcp',
+                                     Timeout  => $sock_timeout);
+     unless ($socket) {
          plugin_log(LOG_ERR, "Graphite.pm: failed to connect to " .
                              "$graphite_host:$graphite_port : $!");
          return 0;
      }
-     print $sock $buff;
-     close($sock);
+     print $socket $buff;
      $buff = '';
      return 1;
 }
 
 sub graphite_flush {
-    send_to_graphite();
+    if ($socket) {
+      send_to_graphite();
+      close($socket);
+      $socket = undef;
+    }
     return 1;
 }
 

--- a/lib/Collectd/Plugins/Graphite.pm
+++ b/lib/Collectd/Plugins/Graphite.pm
@@ -169,7 +169,14 @@ sub send_to_graphite {
                              "$graphite_host:$graphite_port : $!");
          return 0;
      }
-     print $socket $buff;
+
+     unless (print $socket $buff) {
+         plugin_log(LOG_ERR, "Graphite.pm: failed write to " .
+                             "$graphite_host:$graphite_port : $!");
+         close($socket);
+         $socket = undef;
+         return 0;
+     }
      $buff = '';
      return 1;
 }


### PR DESCRIPTION
Instead of opening and closing the socket on every write, this change keeps the socket open the first time it's required and closes it on flush.

Due to the way the collectd-perl works with threads, a separate socket will be maintained for each collectd thread. On my systems this means 5 connections. I think this is a good trade-off to constant open/close of sockets.

If the print to the socket fails then close it so the next time around it will be re-created.
